### PR TITLE
Bugfix/refresh token

### DIFF
--- a/n26/api.py
+++ b/n26/api.py
@@ -10,23 +10,6 @@ GET = "get"
 POST = "post"
 
 
-# Api class can be imported as a library in order to use it within applications
-def _refresh_token(refresh_token):
-    """
-    Refreshes an authentication token
-    :param refresh_token: the refresh token issued by the server when requesting a token
-    :return: the refreshed token data
-    """
-    values_token = {
-        'grant_type': 'refresh_token',
-        'refresh_token': refresh_token
-    }
-
-    response = requests.post(BASE_URL + '/oauth/token', data=values_token, headers=BASIC_AUTH_HEADERS)
-    response.raise_for_status()
-    return response.json()
-
-
 class Api(object):
     # constructor accepting None to maintain backward compatibility
     def __init__(self, cfg=None):
@@ -195,6 +178,23 @@ class Api(object):
         # add expiration time to expiration in _validate_token()
         response_json["expiration_time"] = time.time() + response_json["expires_in"]
         return response_json
+
+    # Api class can be imported as a library in order to use it within applications
+    @staticmethod
+    def _refresh_token(refresh_token):
+        """
+        Refreshes an authentication token
+        :param refresh_token: the refresh token issued by the server when requesting a token
+        :return: the refreshed token data
+        """
+        values_token = {
+            'grant_type': 'refresh_token',
+            'refresh_token': refresh_token
+        }
+
+        response = requests.post(BASE_URL + '/oauth/token', data=values_token, headers=BASIC_AUTH_HEADERS)
+        response.raise_for_status()
+        return response.json()
 
     @staticmethod
     def _validate_token(token_data):

--- a/n26/api.py
+++ b/n26/api.py
@@ -14,6 +14,7 @@ ACCESS_TOKEN_KEY = "access_token"
 REFRESH_TOKEN_KEY = "refresh_token"
 
 
+# Api class can be imported as a library in order to use it within applications
 class Api(object):
     # constructor accepting None to maintain backward compatibility
     def __init__(self, cfg=None):
@@ -182,7 +183,6 @@ class Api(object):
         response.raise_for_status()
         return response.json()
 
-    # Api class can be imported as a library in order to use it within applications
     @staticmethod
     def _refresh_token(refresh_token):
         """

--- a/n26/api.py
+++ b/n26/api.py
@@ -14,10 +14,16 @@ ACCESS_TOKEN_KEY = "access_token"
 REFRESH_TOKEN_KEY = "refresh_token"
 
 
-# Api class can be imported as a library in order to use it within applications
 class Api(object):
-    # constructor accepting None to maintain backward compatibility
+    """
+    Api class can be imported as a library in order to use it within applications
+    """
+
     def __init__(self, cfg=None):
+        """
+        # constructor accepting None to maintain backward compatibility
+        :param cfg: configuration object
+        """
         if not cfg:
             cfg = config.get_config()
         self.config = cfg


### PR DESCRIPTION
The refreshed token did not have the `expiration_time` property which caused it to be "always valid" and being reused for API requests even if it had already expired. This would cause authentication errors when using the same `Api` object for sessions longer than 30 minutes (the token expiration time).

I also moved the `_refresh_token` method inside the `Api` class... dunno why it was outside, refactoring mistake I guess.

To make sure typos in key names aren't an issue I also added some constants for them.

This PR is crucial for the Home Assistant component as it will use one Api object for the lifetime of the application.
https://github.com/home-assistant/home-assistant/pull/21920