### PR TITLE
Remove card id config

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,13 +10,16 @@ The idea is to have a convenient command line interface for [n26](https://n26.co
 ### CLI setup
     pip3 install n26
     wget https://raw.githubusercontent.com/femueller/python-n26/master/n26.yml.example -O ~/.config/n26.yml
-    # configure username, password and card ID
+    # configure username and password
     vim ~/.config/n26.yml
 
-You can also specify environment variables with the credentials instead of creating a config file.
+You can also specify environment variables with the credentials.
 
 - N26_USER: username
 - N26_PASSWORD: password
+
+Note that **when specifying both** environment variables as well as a config file their values can be merged.
+When there is a conflict however (i.e. a key is present in both locations) the **enviroment variable values will be preferred**.
 
 ### CLI example
     n26 balance

--- a/README.md
+++ b/README.md
@@ -17,14 +17,13 @@ You can also specify environment variables with the credentials instead of creat
 
 - N26_USER: username
 - N26_PASSWORD: password
-- N26_CARD_ID: card id
 
 ### CLI example
     n26 balance
 
 Or if using environment variables:
 
-    N26_USER=user N26_PASSWORD=passwd N26_CARD_ID:123456789 n26 balance
+    N26_USER=user N26_PASSWORD=passwd n26 balance
 
 ## API
 ### API setup
@@ -42,9 +41,9 @@ This is going to use the same mechanism to load configuration as the CLI tool, t
 
     from n26 import api
     from n26 import config
-    conf = config.Config('username', 'passwd', 'card_id')
-    balance = api.Api(conf)
-    print(balance.get_balance())
+    conf = config.Config('username', 'passwd')
+    client = api.Api(conf)
+    print(client.get_balance())
 
 ## Run locally
     git clone git@github.com:femueller/python-n26.git

--- a/n26.yml.example
+++ b/n26.yml.example
@@ -1,4 +1,3 @@
 n26:
     username: john.doe@example.com
     password: $upersecret
-    card_id: 123456789

--- a/n26/cli.py
+++ b/n26/cli.py
@@ -12,27 +12,38 @@ def cli():
     """Interact with the https://n26.com API via the command line."""
 
 
+client = api.Api()
+
+
 @cli.command()
 def info():
     """ Get account information """
-    account_info = api.Api()
-    print('Account info:')
-    print('-------------')
+    account_info = client.get_account_info()
+
     # TODO: make it python2 compatible using unicode
-    print('Name: ' + str(account_info.get_account_info()['firstName'] + ' ' +
-                         account_info.get_account_info()['lastName']))
-    print('Email: ' + account_info.get_account_info()['email'])
-    print('Nationality: ' + account_info.get_account_info()['nationality'])
-    print('Phone: ' + account_info.get_account_info()['mobilePhoneNumber'])
+    text = """
+    Account info:
+    -------------
+    Name: %s %s
+    Email: %s
+    Nationality: %s
+    Phone: %s
+    """ % (account_info['firstName'],
+           account_info['lastName'],
+           account_info['email'],
+           account_info['nationality'],
+           account_info['mobilePhoneNumber']
+           )
+
+    print(text.strip())
 
 
 @cli.command()
 def balance():
     """ Show account balance """
-    balance = api.Api()
     print('Current balance:')
     print('----------------')
-    print(str(balance.get_balance()['availableBalance']))
+    print(str(client.get_balance()['availableBalance']))
 
 
 @cli.command()
@@ -44,10 +55,9 @@ def browse():
 @cli.command()
 def spaces():
     """ Show spaces """
-    spaces = api.Api()
     print('Spaces:')
     print('----------------')
-    for space in spaces.get_spaces():
+    for space in client.get_spaces():
         balance = space['balance']['availableBalance']
         string = str(space['name']) + ': ' + str(balance)
         if 'goal' in space:
@@ -61,54 +71,48 @@ def spaces():
 # @click.option('--all', default=False, help='Blocks all n26 cards.')
 def card_block():
     """ Blocks the card. """
-    card = api.Api()
-    for i in card.get_cards():
-        card_id = i['id']
-        card.block_card(card_id)
+    for card in client.get_cards():
+        card_id = card['id']
+        client.block_card(card_id)
         print('Blocked card: ' + card_id)
 
 
 @cli.command()
 def card_unblock():
     """ Unblocks the card. """
-    card = api.Api()
-    for i in card.get_cards():
-        card_id = i['id']
-        card.unblock_card(card_id)
+    for card in client.get_cards():
+        card_id = card['id']
+        client.unblock_card(card_id)
         print('Unblocked card: ' + card_id)
 
 
 @cli.command()
 def limits():
     """ Show n26 account limits  """
-    limits = api.Api()
-    print(limits.get_account_limits())
+    print(client.get_account_limits())
 
 
 @cli.command()
 def contacts():
     """ Show your n26 contacts  """
-    contacts = api.Api()
     print('Contacts:')
     print('---------')
-    print(contacts.get_contacts())
+    print(client.get_contacts())
 
 
 @cli.command()
 def statements():
     """ Show your n26 statements  """
-    statements = api.Api()
     print('Statements:')
     print('-----------')
-    print(statements.get_statements())
+    print(client.get_statements())
 
 
 @cli.command()
 @click.option('--limit', default=5, type=click.IntRange(1, 10000), help='Limit transaction output.')
 def transactions(limit):
     """ Show transactions (default: 5) """
-    transactions = api.Api()
-    output = transactions.get_transactions(limit=limit)
+    output = client.get_transactions(limit=limit)
     print('Transactions:')
     print('-------------')
     li = []

--- a/n26/config.py
+++ b/n26/config.py
@@ -1,24 +1,28 @@
-import yaml
 import os
+import sys
 from collections import namedtuple
 
-Config = namedtuple('Config', ['username', 'password', 'card_id'])
+import yaml
+
+Config = namedtuple('Config', ['username', 'password'])
 
 
 def get_config():
     # try to get values from ENV
-    username, password, card_id = [os.environ.get(e)
-                                   for e in ["N26_USER", "N26_PASSWORD", "N26_CARD_ID"]]
+    username, password = [os.environ.get(e)
+                          for e in ["N26_USER", "N26_PASSWORD"]]
 
-    if not username or not password or not card_id:
+    if not username or not password:
         # print('Environment variables not set. trying to load cfg')
 
         config_file = os.path.expanduser('~/.config/n26.yml')
+        if not os.path.exists(config_file):
+            print('Neither environment variables nor config file could be found.')
+            sys.exit(1)
         with open(config_file, 'r') as ymlfile:
             cfg = yaml.load(ymlfile)
 
             username = cfg['n26']['username']
             password = cfg['n26']['password']
-            card_id = cfg['n26']['card_id']
 
-    return Config(username, password, card_id)
+    return Config(username, password)

--- a/n26/config.py
+++ b/n26/config.py
@@ -1,5 +1,4 @@
 import os
-import sys
 from collections import namedtuple
 
 import yaml
@@ -8,21 +7,62 @@ Config = namedtuple('Config', ['username', 'password'])
 
 
 def get_config():
-    # try to get values from ENV
+    config = _read_from_env()
+
+    if not config.username or not config.password:
+        config = _read_from_file(config)
+
+    _validate_config(config)
+
+    return config
+
+
+def _read_from_env():
+    """
+    Try to get values from ENV
+    :return: Config object that may contain None values
+    """
     username, password = [os.environ.get(e)
                           for e in ["N26_USER", "N26_PASSWORD"]]
-
-    if not username or not password:
-        # print('Environment variables not set. trying to load cfg')
-
-        config_file = os.path.expanduser('~/.config/n26.yml')
-        if not os.path.exists(config_file):
-            print('Neither environment variables nor config file could be found.')
-            sys.exit(1)
-        with open(config_file, 'r') as ymlfile:
-            cfg = yaml.load(ymlfile)
-
-            username = cfg['n26']['username']
-            password = cfg['n26']['password']
-
     return Config(username, password)
+
+
+def _read_from_file(config):
+    """
+    Read config file (if possible) and merge it's content with the given config.
+    If the given config already contains values they will be preserved.
+
+    :param config: a config object that might already contain values
+    :return: Config object with added values from config file (if any)
+    """
+    config_file = os.path.expanduser('~/.config/n26.yml')
+    if not os.path.exists(config_file):
+        # config file doesn't exist
+        return config
+
+    with open(config_file, 'r') as ymlfile:
+        cfg = yaml.load(ymlfile)
+
+        if not cfg:
+            raise ValueError("Config file is missing or empty")
+
+        if 'n26' not in cfg:
+            raise ValueError("Config file is missing 'n26' node")
+
+        root_node = cfg['n26']
+        if root_node:
+            if not config.username:
+                config = config._replace(username=root_node.get('username', config.username))
+            if not config.password:
+                config = config._replace(password=root_node.get('password', config.password))
+
+    return config
+
+
+def _validate_config(config):
+    if not config:
+        raise ValueError("Config is None!")
+    if not config.username:
+        raise ValueError('Missing config param: username')
+    if not config.password:
+        raise ValueError('Missing config param: password')

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,10 +1,13 @@
 import functools
+
 import mock
-from n26 import api, config
 import pytest
 
-conf =  config.Config(username='john.doe@example.com',
-                                                password='$upersecret', card_id="123456789")
+from n26 import api, config
+
+conf = config.Config(username='john.doe@example.com',
+                     password='$upersecret')
+
 
 # decorator for patching get_token
 def patch_token(func):
@@ -13,6 +16,7 @@ def patch_token(func):
         with mock.patch('n26.api.Api.get_token') as mock_token:
             mock_token.return_value = 'some token'
             return func(*args, **kwargs)
+
     return wrapper
 
 
@@ -37,25 +41,25 @@ def test_init_explicit():
 
 # test token
 def test_get_token():
+    expected = '12345678-1234-1234-1234-123456789012'
     with mock.patch('n26.api.requests.post') as mock_post:
-       mock_post.return_value.json.return_value = {
-           'access_token': '12345678-1234-1234-1234-123456789012',
-           'token_type': 'bearer',
-           'refresh_token': '12345678-1234-1234-1234-123456789012',
-           'expires_in': 1798,
-           'scope': 'trust',
-           'host_url': 'https://api.tech26.de'
-       }
-       new_api = api.Api(conf)
-       token = new_api._get_token()
-    assert token  == 'some token'
+        mock_post.return_value.json.return_value = {
+            'access_token': expected,
+            'token_type': 'bearer',
+            'refresh_token': '12345678-1234-1234-1234-123456789012',
+            'expires_in': 1798,
+            'scope': 'trust',
+            'host_url': 'https://api.tech26.de'
+        }
+        new_api = api.Api(conf)
+        token = new_api._get_token()
+    assert token == expected
 
 
 # test rest
 @patch_token
 def test_get_account_info(api_object):
     with mock.patch('n26.api.requests.get') as mock_get:
-        mock_get.return_value.json.return_value = {'email':
-                'john.doe@example.com'}
+        mock_get.return_value.json.return_value = {'email': 'john.doe@example.com'}
         info = api_object.get_account_info()
-    assert info  == {'email': 'john.doe@example.com'}
+    assert info == {'email': 'john.doe@example.com'}

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,26 +1,30 @@
-import pytest
-import mock
-from n26 import config
 import os
-import sys
+
+import mock
+
+from n26 import config
 
 PATH = os.path.dirname(os.path.abspath(__file__))
 test_creds = os.path.join(PATH, "test_creds.yml")
 
+
 def test_preconditions():
     assert os.path.exists(test_creds)
 
-@mock.patch.dict(os.environ, {"N26_USER": "john.doe@example.com", "N26_PASSWORD": "$upersecret", "N26_CARD_ID": "123456789"})
+
+@mock.patch.dict(os.environ, {"N26_USER": "john.doe@example.com", "N26_PASSWORD": "$upersecret"})
 def test_environment_variable():
     assert config.get_config() == config.Config(username='john.doe@example.com',
-                                                password='$upersecret', card_id="123456789")
+                                                password='$upersecret')
+
 
 # ensure environment is empty
-@mock.patch.dict(os.environ, {"N26_USER": "", "N26_PASSWORD": "", "N26_CARD_ID": ""})
+@mock.patch.dict(os.environ, {"N26_USER": "", "N26_PASSWORD": ""})
 def test_file(monkeypatch):
     # patch path to local test file
     def mockreturn(path):
         return test_creds
+
     monkeypatch.setattr(os.path, "expanduser", mockreturn)
     assert config.get_config() == config.Config(username='john.doe@example.com',
-                                                password='$upersecret', card_id="123456789")
+                                                password='$upersecret')

--- a/tests/test_creds.yml
+++ b/tests/test_creds.yml
@@ -1,4 +1,3 @@
 n26:
-    username: john.doe@example.com
-    password: $upersecret
-    card_id: "123456789"
+  username: john.doe@example.com
+  password: $upersecret


### PR DESCRIPTION
Like mentioned in #17 I don't think there is a reason to store the card id in the config.
To reduce the config needed for setup of this library I removed all code related to it.

Please correct me if I'm wrong.

I also extended the config logic a bit to make it possible to use `ENV` vars and the config file at the same time and get more helpful error messages in case something is missing in the config.