### PR TITLE
explicitly specify yaml loader

### DIFF
--- a/n26/config.py
+++ b/n26/config.py
@@ -45,7 +45,7 @@ def _read_from_file(config):
         return config
 
     with open(config_file, 'r') as ymlfile:
-        cfg = yaml.load(ymlfile)
+        cfg = yaml.load(ymlfile, Loader=yaml.BaseLoader)
 
         if not cfg:
             raise ValueError("Config file is missing or empty")


### PR DESCRIPTION
Without this a warning is printed on the console:

```
YAMLLoadWarning: calling yaml.load() without Loader=... is deprecated, as the default Loader is unsafe. Please read https://msg.pyyaml.org/load for full details.
```

I used the `BaseLoader` because it should be more than sufficient for a user/pw config file.
See https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation for more info.