### PR TITLE
Feature/status cli command

### DIFF
--- a/n26/cli.py
+++ b/n26/cli.py
@@ -27,10 +27,11 @@ def info():
     account_info = API_CLIENT.get_account_info()
 
     lines = [
-        ["Name:", "%s %s" % (account_info['firstName'], account_info['lastName'])],
-        ["Email:", account_info['email']],
-        ["Nationality:", account_info['nationality']],
-        ["Phone:", account_info['mobilePhoneNumber']]
+        ["Name:", "%s %s" % (account_info.get('firstName'), account_info.get('lastName'))],
+        ["Email:", account_info.get('email')],
+        ["Gender:", account_info.get('gender')],
+        ["Nationality:", account_info.get('nationality')],
+        ["Phone:", account_info.get('mobilePhoneNumber')]
     ]
 
     text = tabulate(lines, [], tablefmt="plain", colalign=["right", "left"])

--- a/n26/cli.py
+++ b/n26/cli.py
@@ -40,6 +40,39 @@ def info():
 
 
 @cli.command()
+def status():
+    """ Get account statuses """
+    account_statuses = API_CLIENT.get_account_statuses()
+
+    lines = [
+        ["Account created:", _timestamp_ms_to_date(account_statuses.get('created'))],
+        ["Account updated:", _timestamp_ms_to_date(account_statuses.get('updated'))],
+        ["Account closed:", account_statuses.get('accountClosed')],
+        ["Card activation completed:", _timestamp_ms_to_date(account_statuses.get('cardActivationCompleted'))],
+        ["Card issued:", _timestamp_ms_to_date(account_statuses.get('cardIssued'))],
+        ["Core data updated:", _timestamp_ms_to_date(account_statuses.get('coreDataUpdated'))],
+        ["Email validation initiated:", _timestamp_ms_to_date(account_statuses.get('emailValidationInitiated'))],
+        ["Email validation completed:", _timestamp_ms_to_date(account_statuses.get('emailValidationCompleted'))],
+        ["First incoming transaction:", _timestamp_ms_to_date(account_statuses.get('firstIncomingTransaction'))],
+        ["Flex account:", account_statuses.get('flexAccount')],
+        ["Flex account confirmed:", _timestamp_ms_to_date(account_statuses.get('flexAccountConfirmed'))],
+        ["Is deceased:", account_statuses.get('isDeceased')],
+        ["Pairing State:", account_statuses.get('pairingState')],
+        ["Phone pairing initiated:", _timestamp_ms_to_date(account_statuses.get('phonePairingInitiated'))],
+        ["Phone pairing completed:", _timestamp_ms_to_date(account_statuses.get('phonePairingCompleted'))],
+        ["Pin definition completed:", _timestamp_ms_to_date(account_statuses.get('pinDefinitionCompleted'))],
+        ["Product selection completed:", _timestamp_ms_to_date(account_statuses.get('productSelectionCompleted'))],
+        ["Signup step:", account_statuses.get('signupStep')],
+        ["Single step signup:", _timestamp_ms_to_date(account_statuses.get('singleStepSignup'))],
+        ["Unpairing process status:", account_statuses.get('unpairingProcessStatus')],
+    ]
+
+    text = tabulate(lines, [], tablefmt="plain", colalign=["right", "left"])
+
+    click.echo(text)
+
+
+@cli.command()
 def balance():
     """ Show account balance """
     balance_data = API_CLIENT.get_balance()

--- a/tests/test_account.py
+++ b/tests/test_account.py
@@ -12,10 +12,12 @@ class AccountTests(N26TestBase):
         result = self._run_cli_cmd(info)
         self.assertIsNotNone(result.output)
 
+    @mock_config()
     @mock_requests(method=GET, response_file="account_statuses.json")
-    def test_get_account_statuses(self):
-        result = self._underTest.get_account_statuses()
-        self.assertIsNotNone(result)
+    def test_get_account_statuses_cli(self):
+        from n26.cli import status
+        result = self._run_cli_cmd(status)
+        self.assertIn("PAIRED", result.output)
 
     @mock_config()
     @mock_requests(method=GET, response_file="account_limits.json")


### PR DESCRIPTION
Added "status" command, to show account statuses.
It may be preferable to show these informations when calling "info" instead but since they are different endpoints I created a new command for them.

Output looks like this:
```
            Account created:  2016-05-25 17:11:14.939000+00:00
            Account updated:  2018-11-07 10:52:17.999000+00:00
             Account closed:
  Card activation completed:  2016-11-18 11:42:22.232000+00:00
                Card issued:  2016-05-25 17:25:36.297000+00:00
          Core data updated:  2016-05-27 07:00:00.691000+00:00
 Email validation initiated:  2016-05-25 17:11:13.794000+00:00
 Email validation completed:  2016-05-25 17:12:26.996000+00:00
 First incoming transaction:  2016-05-27 15:15:23.423000+00:00
               Flex account:  False
     Flex account confirmed:
                Is deceased:
              Pairing State:  PAIRED
    Phone pairing initiated:  2018-12-04 09:26:12.133000+00:00
    Phone pairing completed:  2018-12-04 09:26:12.133000+00:00
   Pin definition completed:  2016-09-01 20:48:26.790000+00:00
Product selection completed:  2016-05-25 17:21:04.041000+00:00
                Signup step:
         Single step signup:  2016-05-25 17:11:13.794000+00:00
   Unpairing process status:
```