### PR TITLE
fixed contact IBAN column title

### DIFF
--- a/n26/cli.py
+++ b/n26/cli.py
@@ -180,7 +180,7 @@ def contacts():
     """ Show your n26 contacts  """
     contacts_data = API_CLIENT.get_contacts()
 
-    headers = ['Id', 'Name', 'Subtitle']
+    headers = ['Id', 'Name', 'IBAN']
     keys = ['id', 'name', 'subtitle']
     text = _create_table_from_dict(headers=headers, value_functions=keys, data=contacts_data, numalign='right')
 


### PR DESCRIPTION
Currently the table column is called "Subtitle" because the json key is called like that. It doesn't make any sense though so I changed it to "IBAN"