### PR TITLE
Feature/human readable date input

### DIFF
--- a/n26/api.py
+++ b/n26/api.py
@@ -118,8 +118,8 @@ class Api(object):
         Note that some parameters can not be combined in a single request (like text_filter and pending) and
         will result in a bad request (400) error.
 
-        :param from_time: earliest transaction time as a Timestamp - milliseconds since 1970 in CET
-        :param to_time: latest transaction time as a Timestamp - milliseconds since 1970 in CET
+        :param from_time: earliest transaction time as a Timestamp > 0 - milliseconds since 1970 in CET
+        :param to_time: latest transaction time as a Timestamp > 0 - milliseconds since 1970 in CET
         :param limit: Limit the number of transactions to return to the given amount - default 20 as the n26 API returns
         only the last 20 transactions by default
         :param pending: show only pending transactions

--- a/n26/cli.py
+++ b/n26/cli.py
@@ -1,5 +1,6 @@
 import webbrowser
 from datetime import datetime, timezone
+from typing import Tuple
 
 import click
 from tabulate import tabulate
@@ -245,26 +246,14 @@ def statements():
               help='End time limit for statistics.')
 @click.option('--text-filter', default=None, type=str, help='Text filter.')
 @click.option('--limit', default=None, type=click.IntRange(1, 10000), help='Limit transaction output.')
-def transactions(categories: str, pending: bool, param_from: datetime, param_to: datetime, text_filter: str,
-                 limit: int):
+def transactions(categories: str, pending: bool, param_from: datetime or None, param_to: datetime or None,
+                 text_filter: str, limit: int):
     """ Show transactions (default: 5) """
     if not pending and not param_from and not limit:
         limit = 5
         click.echo(click.style("Output is limited to {} entries.".format(limit), fg="yellow"))
 
-    from_timestamp = None
-    to_timestamp = None
-    if param_from is not None:
-        from_timestamp = int(param_from.timestamp() * 1000)
-        if param_to is None:
-            # if --from is set, --to must also be set
-            param_to = datetime.utcnow()
-    if param_to is not None:
-        if param_from is None:
-            # if --to is set, --from must also be set
-            from_timestamp = 1
-        to_timestamp = int(param_to.timestamp() * 1000)
-
+    from_timestamp, to_timestamp = _parse_from_to_timestamps(param_from, param_to)
     transactions_data = API_CLIENT.get_transactions(from_time=from_timestamp, to_time=to_timestamp,
                                                     limit=limit, pending=pending, text_filter=text_filter,
                                                     categories=categories)
@@ -307,19 +296,6 @@ def transactions(categories: str, pending: bool, param_from: datetime, param_to:
     click.echo(text.strip())
 
 
-def _day_of_month_extractor(key: str):
-    def extractor(dictionary: dict):
-        value = dictionary.get(key)
-        if value is None:
-            return None
-        else:
-            import inflect
-            engine = inflect.engine()
-            return engine.ordinal(value)
-
-    return extractor
-
-
 @cli.command("standing-orders")
 def standing_orders():
     """Show your standing orders"""
@@ -349,13 +325,15 @@ def standing_orders():
 
 
 @cli.command()
-@click.option('--from', 'param_from', default=None, type=int,
-              help='Start time limit for statistics. Timestamp - milliseconds since 1970 in CET')
-@click.option('--to', default=None, type=int,
-              help='End time limit for statistics. Timestamp - milliseconds since 1970 in CET')
-def statistics(param_from: int, to: int):
+@click.option('--from', 'param_from', default=None, type=click.DateTime(DATETIME_FORMATS),
+              help='Start time limit for statistics.')
+@click.option('--to', 'param_to', default=None, type=click.DateTime(DATETIME_FORMATS),
+              help='End time limit for statistics.')
+def statistics(param_from: datetime or None, param_to: datetime or None):
     """Show your n26 statistics"""
-    statements_data = API_CLIENT.get_statistics(from_time=param_from, to_time=to)
+
+    from_timestamp, to_timestamp = _parse_from_to_timestamps(param_from, param_to)
+    statements_data = API_CLIENT.get_statistics(from_time=from_timestamp, to_time=to_timestamp)
 
     text = "From: %s\n" % (_timestamp_ms_to_date(statements_data["from"]))
     text += "To:   %s\n\n" % (_timestamp_ms_to_date(statements_data["to"]))
@@ -374,6 +352,29 @@ def statistics(param_from: int, to: int):
     text += _create_table_from_dict(headers, keys, statements_data["items"], numalign='right')
 
     click.echo(text.strip())
+
+
+def _parse_from_to_timestamps(param_from: datetime or None, param_to: datetime or None) -> Tuple[int, int]:
+    """
+    Parses cli datetime inputs for "from" and "to" parameters
+    :param param_from: "from" input
+    :param param_to: "to" input
+    :return: timestamps ready to be used by the api
+    """
+    from_timestamp = None
+    to_timestamp = None
+    if param_from is not None:
+        from_timestamp = int(param_from.timestamp() * 1000)
+        if param_to is None:
+            # if --from is set, --to must also be set
+            param_to = datetime.utcnow()
+    if param_to is not None:
+        if param_from is None:
+            # if --to is set, --from must also be set
+            from_timestamp = 1
+        to_timestamp = int(param_to.timestamp() * 1000)
+
+    return from_timestamp, to_timestamp
 
 
 def _timestamp_ms_to_date(epoch_ms: int) -> datetime or None:
@@ -441,6 +442,19 @@ def _datetime_extractor(key: str, date_only: bool = False):
         else:
             time = time.astimezone()
             return time.strftime(fmt)
+
+    return extractor
+
+
+def _day_of_month_extractor(key: str):
+    def extractor(dictionary: dict):
+        value = dictionary.get(key)
+        if value is None:
+            return None
+        else:
+            import inflect
+            engine = inflect.engine()
+            return engine.ordinal(value)
 
     return extractor
 

--- a/n26/const.py
+++ b/n26/const.py
@@ -19,6 +19,8 @@ DAILY_WITHDRAWAL_LIMIT = 'ATM_DAILY_ACCOUNT'
 DAILY_PAYMENT_LIMIT = 'POS_DAILY_ACCOUNT'
 
 DATETIME_FORMATS = [
+    '%m/%d/%Y %H:%M:%S',
+    '%m/%d/%Y',
     '%Y-%m-%d',
     '%Y-%m-%dT%H:%M:%S',
     '%Y-%m-%d %H:%M:%S',

--- a/n26/const.py
+++ b/n26/const.py
@@ -17,3 +17,11 @@ CARD_STATUS_ACTIVE = 'M_ACTIVE'
 
 DAILY_WITHDRAWAL_LIMIT = 'ATM_DAILY_ACCOUNT'
 DAILY_PAYMENT_LIMIT = 'POS_DAILY_ACCOUNT'
+
+DATETIME_FORMATS = [
+    '%Y-%m-%d',
+    '%Y-%m-%dT%H:%M:%S',
+    '%Y-%m-%d %H:%M:%S',
+    '%d.%m.%Y',
+    '%d.%m.%Y %H:%M:%S'
+]

--- a/tests/test_transactions.py
+++ b/tests/test_transactions.py
@@ -10,5 +10,5 @@ class TransactionsTests(N26TestBase):
     @mock_requests(method=GET, response_file="transactions.json")
     def test_transactions_cli(self):
         from n26.cli import transactions
-        result = self._run_cli_cmd(transactions)
+        result = self._run_cli_cmd(transactions, ["--from", "01/30/2019", "--to", "30.01.2020"])
         self.assertIsNotNone(result.output)


### PR DESCRIPTION
Up until now the `--from` and `--to` cli parameters have been timestamps since 1970 CET.
In practice this is unusable for a human though, so I changed this to support human readable datetime string input formats. Accepted formats are listed in the `const.py`:

* `%m/%d/%Y %H:%M:%S`
* `%m/%d/%Y`
* `%Y-%m-%d`
* `%Y-%m-%dT%H:%M:%S`
* `%Y-%m-%d %H:%M:%S`
* `%d.%m.%Y`
* `%d.%m.%Y %H:%M:%S`

I also plan on adding a `--duration` parameter that allows a user to easily get a specific time range  without having to calculate the dates him- or herself.

This PR also adds a `Date` column to the `transactions` output.