### PR TITLE
Bugfix/#48 new authentication flow

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -10,6 +10,7 @@ tabulate = ">=0.8.3"
 PyYAML = "*"
 inflect = "*"
 urllib3 = ">=1.24.2"
+tenacity = ">=5.1.1"
 
 [dev-packages]
 pytest = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "e474a607a20785edab3cfd7a6551736a67fb14562848ac0b430e40c3684ae34b"
+            "sha256": "1cc795baf1d05c70eb4e34a83e285c11c75d04933368d979eb6c03a71b581054"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -18,10 +18,10 @@
     "default": {
         "certifi": {
             "hashes": [
-                "sha256:59b7658e26ca9c7339e00f8f4636cdfe59d34fa37b9b04f6f9e9926b3cece1a5",
-                "sha256:b26104d6835d1f5e49452a26eb2ff87fe7090b89dfcaee5ea2212697e1e1d7ae"
+                "sha256:e4f3620cfea4f83eedc95b24abd9cd56f3c4b146dd0177e83a21b4eb49e21e50",
+                "sha256:fd7c7c74727ddcf00e9acd26bba8da604ffec95bf1c2144e67aff7a8b50e6cef"
             ],
-            "version": "==2019.3.9"
+            "version": "==2019.9.11"
         },
         "chardet": {
             "hashes": [
@@ -45,22 +45,32 @@
             ],
             "version": "==2.8"
         },
-        "pyyaml": {
+        "inflect": {
             "hashes": [
-                "sha256:1adecc22f88d38052fb787d959f003811ca858b799590a5eaa70e63dca50308c",
-                "sha256:436bc774ecf7c103814098159fbb84c2715d25980175292c648f2da143909f95",
-                "sha256:460a5a4248763f6f37ea225d19d5c205677d8d525f6a83357ca622ed541830c2",
-                "sha256:5a22a9c84653debfbf198d02fe592c176ea548cccce47553f35f466e15cf2fd4",
-                "sha256:7a5d3f26b89d688db27822343dfa25c599627bc92093e788956372285c6298ad",
-                "sha256:9372b04a02080752d9e6f990179a4ab840227c6e2ce15b95e1278456664cf2ba",
-                "sha256:a5dcbebee834eaddf3fa7366316b880ff4062e4bcc9787b78c7fbb4a26ff2dd1",
-                "sha256:aee5bab92a176e7cd034e57f46e9df9a9862a71f8f37cad167c6fc74c65f5b4e",
-                "sha256:c51f642898c0bacd335fc119da60baae0824f2cde95b0330b56c0553439f0673",
-                "sha256:c68ea4d3ba1705da1e0d85da6684ac657912679a649e8868bd850d2c299cce13",
-                "sha256:e23d0cc5299223dcc37885dae624f382297717e459ea24053709675a976a3e19"
+                "sha256:4ded1b2a6fcf0fc0397419c7727f131a93b67b80d899f2973be7758628e12b73",
+                "sha256:a82b671b043ddba98ea8b2cf000b31e8b41e9197b3151567239f3bbe215dab7e"
             ],
             "index": "pypi",
-            "version": "==5.1"
+            "version": "==2.1.0"
+        },
+        "pyyaml": {
+            "hashes": [
+                "sha256:0113bc0ec2ad727182326b61326afa3d1d8280ae1122493553fd6f4397f33df9",
+                "sha256:01adf0b6c6f61bd11af6e10ca52b7d4057dd0be0343eb9283c878cf3af56aee4",
+                "sha256:5124373960b0b3f4aa7df1707e63e9f109b5263eca5976c66e08b1c552d4eaf8",
+                "sha256:5ca4f10adbddae56d824b2c09668e91219bb178a1eee1faa56af6f99f11bf696",
+                "sha256:7907be34ffa3c5a32b60b95f4d95ea25361c951383a894fec31be7252b2b6f34",
+                "sha256:7ec9b2a4ed5cad025c2278a1e6a19c011c80a3caaac804fd2d329e9cc2c287c9",
+                "sha256:87ae4c829bb25b9fe99cf71fbb2140c448f534e24c998cc60f39ae4f94396a73",
+                "sha256:9de9919becc9cc2ff03637872a440195ac4241c80536632fffeb6a1e25a74299",
+                "sha256:a5a85b10e450c66b49f98846937e8cfca1db3127a9d5d1e31ca45c3d0bef4c5b",
+                "sha256:b0997827b4f6a7c286c01c5f60384d218dca4ed7d9efa945c3e1aa623d5709ae",
+                "sha256:b631ef96d3222e62861443cc89d6563ba3eeb816eeb96b2629345ab795e53681",
+                "sha256:bf47c0607522fdbca6c9e817a6e81b08491de50f3766a7a0e6a5be7905961b41",
+                "sha256:f81025eddd0327c7d4cfe9b62cf33190e1e736cc6e97502b3ec425f574b3e7a8"
+            ],
+            "index": "pypi",
+            "version": "==5.1.2"
         },
         "requests": {
             "hashes": [
@@ -70,6 +80,13 @@
             "index": "pypi",
             "version": "==2.22.0"
         },
+        "six": {
+            "hashes": [
+                "sha256:3350809f0555b11f552448330d0b52d5f24c91a322ea4a15ef22629740f3761c",
+                "sha256:d16a0141ec1a18405cd4ce8b4613101da75da0e9a7aec5bdd4fa804d0e0eba73"
+            ],
+            "version": "==1.12.0"
+        },
         "tabulate": {
             "hashes": [
                 "sha256:8af07a39377cee1103a5c8b3330a421c2d99b9141e9cc5ddd2e3263fea416943"
@@ -77,13 +94,21 @@
             "index": "pypi",
             "version": "==0.8.3"
         },
-        "urllib3": {
+        "tenacity": {
             "hashes": [
-                "sha256:b246607a25ac80bedac05c6f282e3cdaf3afb65420fd024ac94435cabe6e18d1",
-                "sha256:dbe59173209418ae49d485b87d1681aefa36252ee85884c31346debd19463232"
+                "sha256:6a7511a59145c2e319b7d04ddd93c12d48cc3d3c8fa42c2846d33a620ee91f57",
+                "sha256:a4eb168dbf55ed2cae27e7c6b2bd48ab54dabaf294177d998330cf59f294c112"
             ],
             "index": "pypi",
-            "version": "==1.25.3"
+            "version": "==5.1.1"
+        },
+        "urllib3": {
+            "hashes": [
+                "sha256:2f3eadfea5d92bc7899e75b5968410b749a054b492d5a6379c1344a1481bc2cb",
+                "sha256:9c6c593cb28f52075016307fc26b0a0f8e82bc7d1ff19aaaa959b91710a56c47"
+            ],
+            "index": "pypi",
+            "version": "==1.25.5"
         }
     },
     "develop": {
@@ -110,11 +135,19 @@
         },
         "flake8": {
             "hashes": [
-                "sha256:859996073f341f2670741b51ec1e67a01da142831aa1fdc6242dbf88dffbe661",
-                "sha256:a796a115208f5c03b18f332f7c11729812c8c3ded6c46319c59b53efd3819da8"
+                "sha256:19241c1cbc971b9962473e4438a2ca19749a7dd002dd1a946eaba171b4114548",
+                "sha256:8e9dfa3cecb2400b3738a42c54c3043e821682b9c840b0448c0503f781130696"
             ],
             "index": "pypi",
-            "version": "==3.7.7"
+            "version": "==3.7.8"
+        },
+        "importlib-metadata": {
+            "hashes": [
+                "sha256:aa18d7378b00b40847790e7c27e11673d7fed219354109d0e7b9e5b25dc3ad26",
+                "sha256:d5f18a79777f3aa179c145737780282e27b508fc8fd688cb17c7a813e8bd39af"
+            ],
+            "markers": "python_version < '3.8'",
+            "version": "==0.23"
         },
         "mccabe": {
             "hashes": [
@@ -133,18 +166,24 @@
         },
         "more-itertools": {
             "hashes": [
-                "sha256:2112d2ca570bb7c3e53ea1a35cd5df42bb0fd10c45f0fb97178679c3c03d64c7",
-                "sha256:c3e4748ba1aad8dba30a4886b0b1a2004f9a863837b8654e7059eebf727afa5a"
+                "sha256:409cd48d4db7052af495b09dec721011634af3753ae1ef92d2b32f73a745f832",
+                "sha256:92b8c4b06dac4f0611c0729b2f2ede52b2e1bac1ab48f089c7ddc12e26bb60c4"
             ],
-            "markers": "python_version > '2.7'",
-            "version": "==7.0.0"
+            "version": "==7.2.0"
+        },
+        "packaging": {
+            "hashes": [
+                "sha256:28b924174df7a2fa32c1953825ff29c61e2f5e082343165438812f00d3a7fc47",
+                "sha256:d9551545c6d761f3def1677baf08ab2a3ca17c56879e70fecba2fc4dde4ed108"
+            ],
+            "version": "==19.2"
         },
         "pluggy": {
             "hashes": [
-                "sha256:25a1bc1d148c9a640211872b4ff859878d422bccb59c9965e04eed468a0aa180",
-                "sha256:964cedd2b27c492fbf0b7f58b3284a09cf7f99b0f715941fb24a439b3af1bd1a"
+                "sha256:0db4b7601aae1d35b4a033282da476845aa19185c1e6964b25cf324b5e4ec3e6",
+                "sha256:fa5fa1622fa6dd5c030e9cad086fa19ef6a0cf6d7a2d12318e10cb49d6d68f34"
             ],
-            "version": "==0.11.0"
+            "version": "==0.13.0"
         },
         "py": {
             "hashes": [
@@ -167,13 +206,20 @@
             ],
             "version": "==2.1.1"
         },
+        "pyparsing": {
+            "hashes": [
+                "sha256:6f98a7b9397e206d78cc01df10131398f1c8b8510a2f4d97d9abd82e1aacdd80",
+                "sha256:d9338df12903bbf5d65a0e4e87c2161968b10d2e489652bb47001d82a9b028b4"
+            ],
+            "version": "==2.4.2"
+        },
         "pytest": {
             "hashes": [
-                "sha256:1a8aa4fa958f8f451ac5441f3ac130d9fc86ea38780dd2715e6d5c5882700b24",
-                "sha256:b8bf138592384bd4e87338cb0f256bf5f615398a649d4bd83915f0e4047a5ca6"
+                "sha256:813b99704b22c7d377bbd756ebe56c35252bb710937b46f207100e843440b3c2",
+                "sha256:cc6620b96bc667a0c8d4fa592a8c9c94178a1bd6cc799dbb057dfd9286d31a31"
             ],
             "index": "pypi",
-            "version": "==4.5.0"
+            "version": "==5.1.3"
         },
         "six": {
             "hashes": [
@@ -188,6 +234,13 @@
                 "sha256:f4ebe71925af7b40a864553f761ed559b43544f8f71746c2d756c7fe788ade7c"
             ],
             "version": "==0.1.7"
+        },
+        "zipp": {
+            "hashes": [
+                "sha256:3718b1cbcd963c7d4c5511a8240812904164b7f381b647143a89d3b98f9bcd8e",
+                "sha256:f06903e9f1f43b12d371004b4ac7b06ab39a44adc747266928ae6debfa7b3335"
+            ],
+            "version": "==0.6.0"
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ or use environment variables:
 
 - `N26_USER`: username
 - `N26_PASSWORD`: password
-- `ENV_PARAM_LOGIN_DATA_STORE_PATH`: optional path to store login data
+- `N26_LOGIN_DATA_STORE_PATH`: optional path to store login data (recommended for cli usage)
 
 Note that **when specifying both** environment variables as well as a config file and a key is present in both locations the **enviroment variable values will be preferred**.
 
@@ -57,7 +57,9 @@ Note that **when specifying both** environment variables as well as a config fil
 Since 14th of September 2019 N26 requires a login confirmation 
 (2 factor authentication) from the paired phone N26 app to login on devices that 
 are not paired. This means you will receive a notification on your phone 
-when you start using this library to request data.
+when you start using this library to request data. python-n26 checks 
+for your login confirmation every 5 seconds. If you fail to approve the 
+login request within 60 seconds an exception is raised.
 
 If you do not specify a `login_data_store_path` this login information 
 is only stored in memory. In order to avoid that every CLI command 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ or use environment variables:
 
 - `N26_USER`: username
 - `N26_PASSWORD`: password
-- `N26_LOGIN_DATA_STORE_PATH`: optional path to store login data (recommended for cli usage)
+- `N26_LOGIN_DATA_STORE_PATH`: optional **file** path to store login data (recommended for cli usage)
 
 Note that **when specifying both** environment variables as well as a config file and a key is present in both locations the **enviroment variable values will be preferred**.
 

--- a/README.md
+++ b/README.md
@@ -41,14 +41,31 @@ You can use a YAML configuration file in `~/.config/n26.yml`:
 n26:
   username: "john.doe@example.com"
   password: "$upersecret"
+  login_data_store_path: "~/.config/n26/token_data"
 ```
 
 or use environment variables:
 
 - `N26_USER`: username
 - `N26_PASSWORD`: password
+- `ENV_PARAM_LOGIN_DATA_STORE_PATH`: optional path to store login data
 
 Note that **when specifying both** environment variables as well as a config file and a key is present in both locations the **enviroment variable values will be preferred**.
+
+## Authentication
+
+Since 14th of September 2019 N26 requires a login confirmation 
+(2 factor authentication) from the paired phone N26 app to login on devices that 
+are not paired. This means you will receive a notification on your phone 
+when you start using this library to request data.
+
+If you do not specify a `login_data_store_path` this login information 
+is only stored in memory. In order to avoid that every CLI command 
+requires a new confirmation, the login data retrieved in the above 
+process can be stored on the file system. Please note that **this 
+information must be protected** from the eyes of third parties **at all 
+costs**. You can specify the location to store this data in the 
+[Configuration](#Configuration).
 
 ## Usage
 
@@ -78,7 +95,7 @@ This is going to use the same mechanism to load configuration as the CLI tool, t
 ```python
 from n26 import api
 from n26 import config
-conf = config.Config('username', 'passwd')
+conf = config.Config('username', 'passwd', '~/.config/n26/token_data')
 client = api.Api(conf)
 print(client.get_balance())
 ```

--- a/n26/api.py
+++ b/n26/api.py
@@ -4,6 +4,7 @@ import time
 from pathlib import Path
 
 import requests
+from requests import HTTPError
 from tenacity import retry, stop_after_delay, wait_fixed
 
 from n26 import config
@@ -294,7 +295,8 @@ class Api(object):
                 refresh_token = token_data[REFRESH_TOKEN_KEY]
                 try:
                     token_data = self._refresh_token(refresh_token)
-                except:
+                except HTTPError as ex:
+                    logging.exception(ex)
                     LOGGER.debug("Couldn't refresh token, requesting new token")
                     token_data = self._request_token(self.config.username, self.config.password)
             else:

--- a/n26/api.py
+++ b/n26/api.py
@@ -10,7 +10,8 @@ from n26.config import Config
 from n26.const import DAILY_WITHDRAWAL_LIMIT, DAILY_PAYMENT_LIMIT
 from n26.util import create_request_url
 
-BASE_URL = 'https://api.tech26.de'
+BASE_URL_DE = 'https://api.tech26.de'
+BASE_URL_GLOBAL = 'https://api.tech26.global'
 BASIC_AUTH_HEADERS = {"Authorization": "Basic bXktdHJ1c3RlZC13ZHBDbGllbnQ6c2VjcmV0"}
 USER_AGENT = ("Mozilla/5.0 (X11; Linux x86_64) "
               "AppleWebKit/537.36 (KHTML, like Gecko) "
@@ -22,6 +23,9 @@ POST = "post"
 EXPIRATION_TIME_KEY = "expiration_time"
 ACCESS_TOKEN_KEY = "access_token"
 REFRESH_TOKEN_KEY = "refresh_token"
+
+GRANT_TYPE_PASSWORD = "password"
+GRANT_TYPE_REFRESH_TOKEN = "refresh_token"
 
 
 class Api(object):
@@ -45,46 +49,46 @@ class Api(object):
         """
         Retrieves basic account information
         """
-        return self._do_request(GET, BASE_URL + '/api/me')
+        return self._do_request(GET, BASE_URL_DE + '/api/me')
 
     def get_account_statuses(self) -> dict:
         """
         Retrieves additional account information
         """
-        return self._do_request(GET, BASE_URL + '/api/me/statuses')
+        return self._do_request(GET, BASE_URL_DE + '/api/me/statuses')
 
     def get_addresses(self) -> dict:
         """
         Retrieves a list of addresses of the account owner
         """
-        return self._do_request(GET, BASE_URL + '/api/addresses')
+        return self._do_request(GET, BASE_URL_DE + '/api/addresses')
 
     def get_balance(self) -> dict:
         """
         Retrieves the current balance
         """
-        return self._do_request(GET, BASE_URL + '/api/accounts')
+        return self._do_request(GET, BASE_URL_DE + '/api/accounts')
 
     def get_spaces(self) -> dict:
         """
         Retrieves a list of all spaces
         """
-        return self._do_request(GET, BASE_URL + '/api/spaces')
+        return self._do_request(GET, BASE_URL_DE + '/api/spaces')
 
     def barzahlen_check(self) -> dict:
-        return self._do_request(GET, BASE_URL + '/api/barzahlen/check')
+        return self._do_request(GET, BASE_URL_DE + '/api/barzahlen/check')
 
     def get_cards(self):
         """
         Retrieves a list of all cards
         """
-        return self._do_request(GET, BASE_URL + '/api/v2/cards')
+        return self._do_request(GET, BASE_URL_DE + '/api/v2/cards')
 
     def get_account_limits(self) -> list:
         """
         Retrieves a list of all active account limits
         """
-        return self._do_request(GET, BASE_URL + '/api/settings/account/limits')
+        return self._do_request(GET, BASE_URL_DE + '/api/settings/account/limits')
 
     def set_account_limits(self, daily_withdrawal_limit: int = None, daily_payment_limit: int = None) -> None:
         """
@@ -94,13 +98,13 @@ class Api(object):
         :param daily_payment_limit: daily payment limit
         """
         if daily_withdrawal_limit is not None:
-            self._do_request(POST, BASE_URL + '/api/settings/account/limits', json={
+            self._do_request(POST, BASE_URL_DE + '/api/settings/account/limits', json={
                 "limit": DAILY_WITHDRAWAL_LIMIT,
                 "amount": daily_withdrawal_limit
             })
 
         if daily_payment_limit is not None:
-            self._do_request(POST, BASE_URL + '/api/settings/account/limits', json={
+            self._do_request(POST, BASE_URL_DE + '/api/settings/account/limits', json={
                 "limit": DAILY_PAYMENT_LIMIT,
                 "amount": daily_payment_limit
             })
@@ -109,13 +113,13 @@ class Api(object):
         """
         Retrieves a list of all contacts
         """
-        return self._do_request(GET, BASE_URL + '/api/smrt/contacts')
+        return self._do_request(GET, BASE_URL_DE + '/api/smrt/contacts')
 
     def get_standing_orders(self) -> dict:
         """
         Get a list of standing orders
         """
-        return self._do_request(GET, BASE_URL + '/api/transactions/so')
+        return self._do_request(GET, BASE_URL_DE + '/api/transactions/so')
 
     def get_transactions(self, from_time: int = None, to_time: int = None, limit: int = 20, pending: bool = None,
                          categories: str = None, text_filter: str = None, last_id: str = None) -> dict:
@@ -139,7 +143,7 @@ class Api(object):
             # pending does not support limit
             limit = None
 
-        return self._do_request(GET, BASE_URL + '/api/smrt/transactions', {
+        return self._do_request(GET, BASE_URL_DE + '/api/smrt/transactions', {
             'from': from_time,
             'to': to_time,
             'limit': limit,
@@ -161,7 +165,7 @@ class Api(object):
         """
         Retrieves a list of all statements
         """
-        return self._do_request(GET, BASE_URL + '/api/statements')
+        return self._do_request(GET, BASE_URL_DE + '/api/statements')
 
     def block_card(self, card_id: str) -> dict:
         """
@@ -171,7 +175,7 @@ class Api(object):
         :param card_id: the id of the card to block
         :return: some info about the card (not including it's blocked state... thanks n26!)
         """
-        return self._do_request(POST, BASE_URL + '/api/cards/%s/block' % card_id)
+        return self._do_request(POST, BASE_URL_DE + '/api/cards/%s/block' % card_id)
 
     def unblock_card(self, card_id: str) -> dict:
         """
@@ -181,10 +185,10 @@ class Api(object):
         :param card_id: the id of the card to block
         :return: some info about the card (not including it's unblocked state... thanks n26!)
         """
-        return self._do_request(POST, BASE_URL + '/api/cards/%s/unblock' % card_id)
+        return self._do_request(POST, BASE_URL_DE + '/api/cards/%s/unblock' % card_id)
 
     def get_savings(self) -> dict:
-        return self._do_request(GET, BASE_URL + '/api/hub/savings/accounts')
+        return self._do_request(GET, BASE_URL_DE + '/api/hub/savings/accounts')
 
     def get_statistics(self, from_time: int = 0, to_time: int = int(time.time()) * 1000) -> dict:
         """
@@ -200,13 +204,13 @@ class Api(object):
         if not to_time:
             to_time = int(time.time()) * 1000
 
-        return self._do_request(GET, BASE_URL + '/api/smrt/statistics/categories/%s/%s' % (from_time, to_time))
+        return self._do_request(GET, BASE_URL_DE + '/api/smrt/statistics/categories/%s/%s' % (from_time, to_time))
 
     def get_available_categories(self) -> list:
-        return self._do_request(GET, BASE_URL + '/api/smrt/categories')
+        return self._do_request(GET, BASE_URL_DE + '/api/smrt/categories')
 
     def get_invitations(self) -> list:
-        return self._do_request(GET, BASE_URL + '/api/aff/invitations')
+        return self._do_request(GET, BASE_URL_DE + '/api/aff/invitations')
 
     def _do_request(self, method: str = GET, url: str = "/", params: dict = None,
                     json: dict = None) -> list or dict or None:
@@ -279,59 +283,32 @@ class Api(object):
 
         return self._token_data[ACCESS_TOKEN_KEY]
 
-    @staticmethod
-    def _request_token(username: str, password: str):
+    def _request_token(self, username: str, password: str):
         """
         Request an authentication token from the server
         :return: the token or None if the response did not contain a token
         """
+        mfa_token = self._initiate_authentication_flow(username, password)
+        self._request_mfa_approval(mfa_token)
+        return self._complete_authentication_flow(mfa_token)
+
+    @staticmethod
+    def _initiate_authentication_flow(username: str, password: str) -> str:
         values_token = {
-            "grant_type": "password",
+            "grant_type": GRANT_TYPE_PASSWORD,
             "username": username,
             "password": password
         }
+        # TODO: Seems like the user-agent is not necessary but might be a good idea anyway
+        response = requests.post(BASE_URL_GLOBAL + "/oauth/token", data=values_token, headers=BASIC_AUTH_HEADERS)
+        if response.status_code != 403:
+            raise ValueError("Unexpected response for initial auth request: {}".format(response.text))
 
-        def initiate_authentication_flow() -> str:
-            # TODO: Seems like the user-agent is not necessary but might be a good idea anyway
-            response = requests.post(BASE_URL + "/oauth/token", data=values_token, headers=BASIC_AUTH_HEADERS)
-            if response.status_code != 403:
-                raise ValueError("Unexpected response for initial auth request: {}".format(response.text))
-
-            response_data = response.json()
-            if response_data.get("error", "") == "mfa_required":
-                return response_data["mfaToken"]
-            else:
-                raise ValueError("Unexpected response data")
-
-        @retry(wait=wait_fixed(5), stop=stop_after_delay(60))
-        def complete_authentication_flow(mfa_token: str) -> dict:
-            mfa_response_data = {
-                "grant_type": "mfa_oob",
-                "mfaToken": mfa_token
-            }
-            response = requests.post(BASE_URL + "/oauth/token", data=mfa_response_data, headers=BASIC_AUTH_HEADERS)
-            response.raise_for_status()
-            tokens = response.json()
-            return tokens
-
-        def request_mfa_approval(mfa_token: str):
-            mfa_data = {
-                "challengeType": "oob",
-                "mfaToken": mfa_token
-            }
-            response = requests.post(
-                BASE_URL + "/api/mfa/challenge",
-                json=mfa_data,
-                headers={
-                    **BASIC_AUTH_HEADERS,
-                    "User-Agent": USER_AGENT,
-                    "Content-Type": "application/json"
-                })
-            response.raise_for_status()
-
-        mfa_token = initiate_authentication_flow()
-        request_mfa_approval(mfa_token)
-        return complete_authentication_flow(mfa_token)
+        response_data = response.json()
+        if response_data.get("error", "") == "mfa_required":
+            return response_data["mfaToken"]
+        else:
+            raise ValueError("Unexpected response data")
 
     @staticmethod
     def _refresh_token(refresh_token: str):
@@ -341,13 +318,40 @@ class Api(object):
         :return: the refreshed token data
         """
         values_token = {
-            'grant_type': REFRESH_TOKEN_KEY,
-            'refresh_token': refresh_token
+            'grant_type': GRANT_TYPE_REFRESH_TOKEN,
+            'refresh_token': refresh_token,
         }
 
-        response = requests.post(BASE_URL + '/oauth/token', data=values_token, headers=BASIC_AUTH_HEADERS)
+        response = requests.post(BASE_URL_GLOBAL + '/oauth/token', data=values_token, headers=BASIC_AUTH_HEADERS)
         response.raise_for_status()
         return response.json()
+
+    @staticmethod
+    def _request_mfa_approval(mfa_token: str):
+        mfa_data = {
+            "challengeType": "oob",
+            "mfaToken": mfa_token
+        }
+        response = requests.post(
+            BASE_URL_DE + "/api/mfa/challenge",
+            json=mfa_data,
+            headers={
+                **BASIC_AUTH_HEADERS,
+                "User-Agent": USER_AGENT,
+                "Content-Type": "application/json"
+            })
+        response.raise_for_status()
+
+    @retry(wait=wait_fixed(5), stop=stop_after_delay(60))
+    def _complete_authentication_flow(self, mfa_token: str) -> dict:
+        mfa_response_data = {
+            "grant_type": "mfa_oob",
+            "mfaToken": mfa_token
+        }
+        response = requests.post(BASE_URL_DE + "/oauth/token", data=mfa_response_data, headers=BASIC_AUTH_HEADERS)
+        response.raise_for_status()
+        tokens = response.json()
+        return tokens
 
     @staticmethod
     def _validate_token(token_data: dict):

--- a/n26/config.py
+++ b/n26/config.py
@@ -5,9 +5,16 @@ import yaml
 
 ENV_PARAM_USER = "N26_USER"
 ENV_PARAM_PASSWORD = "N26_PASSWORD"
+ENV_PARAM_LOGIN_DATA_STORE_PATH = "N26_LOGIN_DATA_STORE_PATH"
 
-CONFIG_FILE_PATH = "~/.config/n26.yml"
-Config = namedtuple('Config', ['username', 'password'])
+CONFIG_DIRECTORY = "~/.config"
+CONFIG_FILE_NAME = "n26.yml"
+CONFIG_FILE_PATH = os.path.join(CONFIG_DIRECTORY, CONFIG_FILE_NAME)
+Config = namedtuple('Config', [
+    'username',
+    'password',
+    'login_data_store_path'
+])
 
 
 def get_config():
@@ -26,9 +33,10 @@ def _read_from_env():
     Try to get values from ENV
     :return: Config object that may contain None values
     """
-    username, password = [os.environ.get(e)
-                          for e in [ENV_PARAM_USER, ENV_PARAM_PASSWORD]]
-    return Config(username, password)
+    username, password, login_data_store_path = [
+        os.environ.get(e) for e in [ENV_PARAM_USER, ENV_PARAM_PASSWORD, ENV_PARAM_LOGIN_DATA_STORE_PATH]
+    ]
+    return Config(username, password, login_data_store_path)
 
 
 def _read_from_file(config):
@@ -59,6 +67,9 @@ def _read_from_file(config):
                 config = config._replace(username=root_node.get('username', config.username))
             if not config.password:
                 config = config._replace(password=root_node.get('password', config.password))
+            if not config.login_data_store_path:
+                config = config._replace(
+                    login_data_store_path=root_node.get('login_data_store_path', config.login_data_store_path))
 
     return config
 

--- a/n26/util.py
+++ b/n26/util.py
@@ -1,0 +1,25 @@
+def create_request_url(url: str, params: dict = None):
+    """
+    Adds query params to the given url
+
+    :param url: the url to extend
+    :param params: query params as a keyed dictionary
+    :return: the url including the given query params
+    """
+
+    if params:
+        first_param = True
+        for k, v in sorted(params.items(), key=lambda entry: entry[0]):
+            if not v:
+                # skip None values
+                continue
+
+            if first_param:
+                url += '?'
+                first_param = False
+            else:
+                url += '&'
+
+            url += "%s=%s" % (k, v)
+
+    return url

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
     url='https://github.com/femueller/python-n26',
     download_url='https://github.com/femueller/python-n26/tarball/{version}'.format(version=VERSION),
     version=VERSION,
-    install_requires=['requests', 'pyyaml', 'click', 'tabulate', 'inflect'],
+    install_requires=['requests', 'pyyaml', 'click', 'tabulate', 'inflect', 'tenacity'],
     test_requires=['mock', 'pytest'],
     packages=[
         'n26'

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -7,8 +7,9 @@ class ApiTests(N26TestBase):
     """Common Api tests"""
 
     def test_create_request_url(self):
+        from n26.util import create_request_url
         expected = "https://api.tech26.de?bar=baz&foo=bar"
-        result = self._underTest._create_request_url(BASE_URL, {
+        result = create_request_url(BASE_URL, {
             "foo": "bar",
             "bar": "baz"
         })
@@ -30,7 +31,6 @@ class ApiTests(N26TestBase):
         expected = "12345678-1234-abcd-abcd-1234567890ab"
         result = self._underTest.get_token()
         self.assertIsNot(result, expected)
-        result = self._underTest._refresh_token("bla")
         self.assertEqual(result["access_token"], expected)
 
     @mock_config()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -28,10 +28,10 @@ class ApiTests(N26TestBase):
 
     @mock_requests(url_regex=".*/token", method=POST, response_file="refresh_token.json")
     def test_refresh_token(self):
+        refresh_token = "12345678-1234-abcd-abcd-1234567890ab"
         expected = "12345678-1234-abcd-abcd-1234567890ab"
-        result = self._underTest.get_token()
-        self.assertIsNot(result, expected)
-        self.assertEqual(result["access_token"], expected)
+        result = self._underTest._refresh_token(refresh_token)
+        self.assertEqual(result['access_token'], expected)
 
     @mock_config()
     def test_init_without_config(self):
@@ -40,7 +40,8 @@ class ApiTests(N26TestBase):
 
     def test_init_with_config(self):
         conf = config.Config(username='john.doe@example.com',
-                             password='$upersecret')
+                             password='$upersecret',
+                             login_data_store_path=None)
         api_client = api.Api(conf)
         self.assertIsNotNone(api_client.config)
         self.assertEqual(api_client.config, conf)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,5 +1,5 @@
 from n26 import api, config
-from n26.api import BASE_URL, POST, GET
+from n26.api import BASE_URL_DE, POST, GET
 from tests.test_api_base import N26TestBase, mock_auth_token, mock_requests, mock_config
 
 
@@ -9,7 +9,7 @@ class ApiTests(N26TestBase):
     def test_create_request_url(self):
         from n26.util import create_request_url
         expected = "https://api.tech26.de?bar=baz&foo=bar"
-        result = create_request_url(BASE_URL, {
+        result = create_request_url(BASE_URL_DE, {
             "foo": "bar",
             "bar": "baz"
         })

--- a/tests/test_api_base.py
+++ b/tests/test_api_base.py
@@ -48,7 +48,9 @@ def mock_config(username: str = "john.doe@example.com", password: str = "$uperse
         def wrapper(*args, **kwargs):
             with mock.patch('n26.config.get_config') as mock_config:
                 from n26 import config
-                mock_config.return_value = config.Config(username=username, password=password)
+                mock_config.return_value = config.Config(
+                    username=username, password=password,
+                    login_data_store_path=None)
                 return function(*args, **kwargs)
 
         return wrapper

--- a/tests/test_api_base.py
+++ b/tests/test_api_base.py
@@ -1,5 +1,6 @@
 import functools
 import json
+import logging
 import os
 import re
 import unittest
@@ -150,6 +151,14 @@ class N26TestBase(unittest.TestCase):
         config.CONFIG_FILE_PATH = self.CONFIG_FILE
 
         self._underTest = api.Api()
+
+        logger = logging.getLogger("n26")
+        logger.setLevel(logging.DEBUG)
+        ch = logging.StreamHandler()
+        ch.setLevel(logging.DEBUG)
+        formatter = logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s")
+        ch.setFormatter(formatter)
+        logger.addHandler(ch)
 
     def tearDown(self):
         """

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -12,11 +12,13 @@ class ConfigTests(N26TestBase):
 
     EXPECTED_FILE_CONF = config.Config(
         username='john.doe@example.com',
-        password='$upersecret')
+        password='$upersecret',
+        login_data_store_path=None)
 
     EXPECTED_ENV_CONF = config.Config(
         username='john.doe@env.com',
-        password='env!?')
+        password='env!?',
+        login_data_store_path=None)
 
     def test_preconditions(self):
         assert os.path.exists(self.CONFIG_FILE)


### PR DESCRIPTION
fixes #48 

This PR implements the new 2FA required by N26.

To prevent having to reapprove every single CLI command a new config option has been added to specify a file path where access token data can be saved on the file system. This config option is optional though and by default `None`. If this config option is not set the token data will only be stored in memory and never written to disk.

After issuing a command without a previous authentication attempt the user has 60 seconds to approve the login using his paired phone and N26 app. To implement a simple "retry" logic I added the `tenacity` dependency.