### PR TITLE
Adding new mandatory "device-token" header to fix auth issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,26 @@ Note that **when specifying both** environment variables as well as a config fil
 
 ## Authentication
 
+### Device Token
+
+Since 17th of June 2020 N26 requires a device_token to differentiate clients. This requires you to specify the `DEVICE_TOKEN`
+config option with a UUID of your choice. To generate a UUID you can use f.ex. one of the following options:
+
+Using python:
+```python
+python -c 'import uuid; print(uuid.uuid4())'
+```
+
+Using linux built-in tools:
+```shell
+> uuidgen
+```
+
+Using a website:
+[https://www.uuidgenerator.net/](https://www.uuidgenerator.net/)
+
+### 2FA
+
 Since 14th of September 2019 N26 requires a login confirmation (2 factor authentication). 
 
 There are two options here:

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ If you want to use environment variables:
 
 - `N26_USER`: username
 - `N26_PASSWORD`: password
+- `N26_DEVICE_TOKEN`: random [uuid](https://de.wikipedia.org/wiki/Universally_Unique_Identifier) to identify the device
 - `N26_LOGIN_DATA_STORE_PATH`: optional **file** path to store login data (recommended for cli usage)
 - `N26_MFA_TYPE`: `app` will use the paired app as 2 factor authentication, `sms` will use SMS to the registered number.
 
@@ -70,7 +71,7 @@ If you do not specify a `login_data_store_path` this login information is only s
 Or if using environment variables:
 
 ```bash
-> N26_USER=user N26_PASSWORD=passwd N26_MFA_TYPE=app n26 balance
+> N26_USER=user N26_PASSWORD=passwd N26_DEVICE_TOKEN=00000000-0000-0000-0000-000000000000 N26_MFA_TYPE=app n26 balance
 123.45 EUR
 ```
 

--- a/n26.tml.example
+++ b/n26.tml.example
@@ -1,5 +1,6 @@
 [n26]
 username = "john.doe@example.com"
 password = "$upersecret"
+device_token = "00000000-0000-0000-0000-000000000000"
 login_data_store_path = "~/.config/n26/token_data"
 mfa_type = "app"

--- a/n26.yml.example
+++ b/n26.yml.example
@@ -1,5 +1,6 @@
 n26:
     username: john.doe@example.com
     password: $upersecret
+    device_token: 00000000-0000-0000-0000-000000000000
     login_data_store_path: "~/.config/n26/token_data"
     mfa_type: app

--- a/n26/api.py
+++ b/n26/api.py
@@ -393,7 +393,7 @@ class Api(object):
             "password": password
         }
         # TODO: Seems like the user-agent is not necessary but might be a good idea anyway
-        response = requests.post(BASE_URL_GLOBAL + "/oauth/token/", data=values_token, headers=BASIC_AUTH_HEADERS)
+        response = requests.post(BASE_URL_GLOBAL + "/oauth2/token", data=values_token, headers=BASIC_AUTH_HEADERS)
         if response.status_code != 403:
             raise ValueError("Unexpected response for initial auth request: {}".format(response.text))
 
@@ -416,7 +416,7 @@ class Api(object):
             'refresh_token': refresh_token,
         }
 
-        response = requests.post(BASE_URL_GLOBAL + '/oauth/token/', data=values_token, headers=BASIC_AUTH_HEADERS)
+        response = requests.post(BASE_URL_GLOBAL + '/oauth2/token', data=values_token, headers=BASIC_AUTH_HEADERS)
         response.raise_for_status()
         return response.json()
 
@@ -456,7 +456,7 @@ class Api(object):
         else:
             mfa_response_data['grant_type'] = "mfa_oob"
 
-        response = requests.post(BASE_URL_DE + "/oauth/token/", data=mfa_response_data, headers=BASIC_AUTH_HEADERS)
+        response = requests.post(BASE_URL_DE + "/oauth2/token", data=mfa_response_data, headers=BASIC_AUTH_HEADERS)
         response.raise_for_status()
         tokens = response.json()
         return tokens

--- a/n26/api.py
+++ b/n26/api.py
@@ -48,6 +48,7 @@ class Api(object):
             cfg = Config()
         self.config = cfg
         self._token_data = {}
+        BASIC_AUTH_HEADERS["device-token"] = self.config.DEVICE_TOKEN.value
 
     @property
     def token_data(self) -> dict:

--- a/n26/config.py
+++ b/n26/config.py
@@ -47,6 +47,17 @@ class Config(ConfigBase):
         secret=True
     )
 
+    DEVICE_TOKEN = StringConfigEntry(
+        description="N26 device token",
+        example="00000000-0000-0000-0000-000000000000",
+        key_path=[
+            NODE_ROOT,
+            "device_token"
+        ],
+        required=True,
+        regex="[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}",
+    )
+
     LOGIN_DATA_STORE_PATH = FileConfigEntry(
         description="File path to store login data",
         example="~/.config/n26/token_data",

--- a/tests/test_creds.yml
+++ b/tests/test_creds.yml
@@ -1,4 +1,5 @@
 n26:
   username: john.doe@example.com
   password: $upersecret
+  device_token: 5a136085-abd8-4e71-9402-e0a61dd1dc81
   mfa_type: app


### PR DESCRIPTION
fixes #81 

Here is a fix for the current authentication issues with N26. It seems like there is a new mandatory http-header during authentication. The value must be a valid UUID.
I found out about it with the help of https://github.com/femueller/python-n26/issues/81#issuecomment-653692469 after playing around with the sniffed data.

My idea is to let the user set a token via config or environment, to have a fixed but unique identifier per device. In my tests the device token must be the same during entire authentication and token refreshing.
I know, that this is kind of breaking, because a change of the config is needed after an update, but I believe it is the best trade-off in terms of reliability and security.

I thought about generating a token in the code and saving it in the local token data file, but because it is optional to use, it doesn't seem like the right place to me.
There would also be the possibility to have a fixed token in the code, but this is probably the worst solution for security.

I also updated the oauth urls from "/oauth/token/" to "/oauth2/token", because the new one is the same as in the sniffed data and has in my opinion the lowest likeliness to break in the future.