### PR TITLE
Fix handling of SMS OTP whose first digit is 0

### DIFF
--- a/n26/api.py
+++ b/n26/api.py
@@ -452,7 +452,9 @@ class Api(object):
             mfa_response_data['grant_type'] = "mfa_otp"
 
             hint = click.style("Enter the 6 digit SMS OTP code", fg="yellow")
-            mfa_response_data['otp'] = click.prompt(hint, type=int)
+
+            # type=str because it can have significant leading zeros
+            mfa_response_data['otp'] = click.prompt(hint, type=str)
         else:
             mfa_response_data['grant_type'] = "mfa_oob"
 


### PR DESCRIPTION
The cast to int was removing that digit, but it's meaningful.

Without this change, it just keeps requesting the same OTP without sending a new one, and never accepting the user input.

----

That was originally added in #70 (the original PR that added SMS MFA support) as part of a code review that requested changing `input()` to use click. There was no requirement to use a type, and the original version worked just fine with `input()` returning a string.