### PR TITLE
Statements pdf download

### DIFF
--- a/n26/api.py
+++ b/n26/api.py
@@ -223,6 +223,12 @@ class Api(object):
         )
         return self.get_transactions(limit=limit)
 
+    def get_balance_statement(self, statement_url: str):
+        """
+        Retrieves a balance statement as pdf content
+        """
+        return self._do_request(GET, BASE_URL_DE + statement_url, to_json=False)
+
     def get_statements(self) -> list:
         """
         Retrieves a list of all statements
@@ -275,7 +281,7 @@ class Api(object):
         return self._do_request(GET, BASE_URL_DE + '/api/aff/invitations')
 
     def _do_request(self, method: str = GET, url: str = "/", params: dict = None,
-                    json: dict = None, headers: dict = None) -> list or dict or None:
+                    json: dict = None, headers: dict = None, to_json: bool = True) -> list or dict or None:
         """
         Executes a http request based on the given parameters
 
@@ -303,7 +309,7 @@ class Api(object):
         response.raise_for_status()
         # some responses do not return data so we just ignore the body in that case
         if len(response.content) > 0:
-            return response.json()
+            return response.json() if to_json else response.content
 
     def get_encryption_key(self, public_key: str = None) -> dict:
         """

--- a/n26/api.py
+++ b/n26/api.py
@@ -226,8 +226,9 @@ class Api(object):
     def get_balance_statement(self, statement_url: str):
         """
         Retrieves a balance statement as pdf content
+        :param statement_url: Download URL of a balance statement document
         """
-        return self._do_request(GET, BASE_URL_DE + statement_url, to_json=False)
+        return self._do_request(GET, BASE_URL_DE + statement_url)
 
     def get_statements(self) -> list:
         """
@@ -281,7 +282,7 @@ class Api(object):
         return self._do_request(GET, BASE_URL_DE + '/api/aff/invitations')
 
     def _do_request(self, method: str = GET, url: str = "/", params: dict = None,
-                    json: dict = None, headers: dict = None, to_json: bool = True) -> list or dict or None:
+                    json: dict = None, headers: dict = None) -> list or dict or None:
         """
         Executes a http request based on the given parameters
 
@@ -309,7 +310,10 @@ class Api(object):
         response.raise_for_status()
         # some responses do not return data so we just ignore the body in that case
         if len(response.content) > 0:
-            return response.json() if to_json else response.content
+            if "application/json" in response.headers.get("Content-Type", ""):
+                return response.json()
+            else:
+                return response.content
 
     def get_encryption_key(self, public_key: str = None) -> dict:
         """

--- a/n26/cli.py
+++ b/n26/cli.py
@@ -345,14 +345,18 @@ def statements(id: str or None, param_from: datetime or None, param_to: datetime
 
     click.echo(text.strip())
 
-    if download:
-        output_path = path.abspath(download)
-        if path.isdir(output_path):
-            for statement in statements_data:
-                statement_data = API_CLIENT.get_balance_statement(statement['url'])
-                filepath = path.join(output_path, f'{statement["id"]}.pdf')
-                with open(filepath, 'wb') as f:
-                    f.write(statement_data)
+    if not download:
+        return
+
+    output_path = path.abspath(download)
+    if not path.isdir(output_path):
+        return
+
+    for statement in statements_data:
+        filepath = path.join(output_path, f'{statement["id"]}.pdf')
+        statement_data = API_CLIENT.get_balance_statement(statement['url'])
+        with open(filepath, 'wb') as f:
+            f.write(statement_data)
 
 
 @cli.command()

--- a/n26/cli.py
+++ b/n26/cli.py
@@ -321,7 +321,7 @@ def contacts():
 @click.option('--download', default=None, type=str,
               help='Download statements as pdf to this dir.')
 @auth_decorator
-def statements(id: str or None, param_from: datetime or None, param_to: datetime or None, download: str = None):
+def statements(id: str or None, param_from: datetime or None, param_to: datetime or None, download: str or None):
     """ Show your n26 statements  """
     statements_data = API_CLIENT.get_statements()
     statements_filter = None
@@ -354,7 +354,7 @@ def statements(id: str or None, param_from: datetime or None, param_to: datetime
         return
 
     for statement in statements_data:
-        filepath = path.join(output_path, f'{statement["id"]}.pdf')
+        filepath = path.join(output_path, '{0}.pdf'.format(statement["id"]))
         statement_data = API_CLIENT.get_balance_statement(statement['url'])
         with open(filepath, 'wb') as f:
             f.write(statement_data)

--- a/n26/cli.py
+++ b/n26/cli.py
@@ -351,6 +351,7 @@ def statements(id: str or None, param_from: datetime or None, param_to: datetime
 
     output_path = path.abspath(download)
     if not path.isdir(output_path):
+        click.echo("Target path doesn't exist or is not a folder, skipping download.")
         return
 
     for statement in statements_data:

--- a/n26/cli.py
+++ b/n26/cli.py
@@ -324,6 +324,7 @@ def contacts():
 def statements(id: str or None, param_from: datetime or None, param_to: datetime or None, download: str = None):
     """ Show your n26 statements  """
     statements_data = API_CLIENT.get_statements()
+    statements_filter = None
 
     if id:
         statements_filter = lambda statement: statement['id'] == id

--- a/tests/api_responses/statement.pdf
+++ b/tests/api_responses/statement.pdf
@@ -1,0 +1,198 @@
+%PDF-1.3
+%‚„œ”
+
+1 0 obj
+<<
+/Type /Catalog
+/Outlines 2 0 R
+/Pages 3 0 R
+>>
+endobj
+
+2 0 obj
+<<
+/Type /Outlines
+/Count 0
+>>
+endobj
+
+3 0 obj
+<<
+/Type /Pages
+/Count 2
+/Kids [ 4 0 R 6 0 R ] 
+>>
+endobj
+
+4 0 obj
+<<
+/Type /Page
+/Parent 3 0 R
+/Resources <<
+/Font <<
+/F1 9 0 R 
+>>
+/ProcSet 8 0 R
+>>
+/MediaBox [0 0 612.0000 792.0000]
+/Contents 5 0 R
+>>
+endobj
+
+5 0 obj
+<< /Length 1074 >>
+stream
+2 J
+BT
+0 0 0 rg
+/F1 0027 Tf
+57.3750 722.2800 Td
+( A Simple PDF File ) Tj
+ET
+BT
+/F1 0010 Tf
+69.2500 688.6080 Td
+( This is a small demonstration .pdf file - ) Tj
+ET
+BT
+/F1 0010 Tf
+69.2500 664.7040 Td
+( just for use in the Virtual Mechanics tutorials. More text. And more ) Tj
+ET
+BT
+/F1 0010 Tf
+69.2500 652.7520 Td
+( text. And more text. And more text. And more text. ) Tj
+ET
+BT
+/F1 0010 Tf
+69.2500 628.8480 Td
+( And more text. And more text. And more text. And more text. And more ) Tj
+ET
+BT
+/F1 0010 Tf
+69.2500 616.8960 Td
+( text. And more text. Boring, zzzzz. And more text. And more text. And ) Tj
+ET
+BT
+/F1 0010 Tf
+69.2500 604.9440 Td
+( more text. And more text. And more text. And more text. And more text. ) Tj
+ET
+BT
+/F1 0010 Tf
+69.2500 592.9920 Td
+( And more text. And more text. ) Tj
+ET
+BT
+/F1 0010 Tf
+69.2500 569.0880 Td
+( And more text. And more text. And more text. And more text. And more ) Tj
+ET
+BT
+/F1 0010 Tf
+69.2500 557.1360 Td
+( text. And more text. And more text. Even more. Continued on page 2 ...) Tj
+ET
+endstream
+endobj
+
+6 0 obj
+<<
+/Type /Page
+/Parent 3 0 R
+/Resources <<
+/Font <<
+/F1 9 0 R 
+>>
+/ProcSet 8 0 R
+>>
+/MediaBox [0 0 612.0000 792.0000]
+/Contents 7 0 R
+>>
+endobj
+
+7 0 obj
+<< /Length 676 >>
+stream
+2 J
+BT
+0 0 0 rg
+/F1 0027 Tf
+57.3750 722.2800 Td
+( Simple PDF File 2 ) Tj
+ET
+BT
+/F1 0010 Tf
+69.2500 688.6080 Td
+( ...continued from page 1. Yet more text. And more text. And more text. ) Tj
+ET
+BT
+/F1 0010 Tf
+69.2500 676.6560 Td
+( And more text. And more text. And more text. And more text. And more ) Tj
+ET
+BT
+/F1 0010 Tf
+69.2500 664.7040 Td
+( text. Oh, how boring typing this stuff. But not as boring as watching ) Tj
+ET
+BT
+/F1 0010 Tf
+69.2500 652.7520 Td
+( paint dry. And more text. And more text. And more text. And more text. ) Tj
+ET
+BT
+/F1 0010 Tf
+69.2500 640.8000 Td
+( Boring.  More, a little more text. The end, and just as well. ) Tj
+ET
+endstream
+endobj
+
+8 0 obj
+[/PDF /Text]
+endobj
+
+9 0 obj
+<<
+/Type /Font
+/Subtype /Type1
+/Name /F1
+/BaseFont /Helvetica
+/Encoding /WinAnsiEncoding
+>>
+endobj
+
+10 0 obj
+<<
+/Creator (Rave \(http://www.nevrona.com/rave\))
+/Producer (Nevrona Designs)
+/CreationDate (D:20060301072826)
+>>
+endobj
+
+xref
+0 11
+0000000000 65535 f
+0000000019 00000 n
+0000000093 00000 n
+0000000147 00000 n
+0000000222 00000 n
+0000000390 00000 n
+0000001522 00000 n
+0000001690 00000 n
+0000002423 00000 n
+0000002456 00000 n
+0000002574 00000 n
+
+trailer
+<<
+/Size 11
+/Root 1 0 R
+/Info 10 0 R
+>>
+
+startxref
+2714
+%%EOF

--- a/tests/test_account.py
+++ b/tests/test_account.py
@@ -73,8 +73,8 @@ class AccountTests(N26TestBase):
     @mock_requests(method=GET, response_file="statements.json")
     def test_get_statements_by_id_cli(self):
         from n26.cli import statements
-        result = self._run_cli_cmd(statements, ['--id', 'statement-2017-01'])
-        self.assertEqual(len(result.output.split('\n')), 4)
+        result = self._run_cli_cmd(statements, ["--id", "statement-2017-01"])
+        self.assertEqual(len(result.output.split("\n")), 4)
         self.assertNotIn("2016-11", result.output)
         self.assertIn("/api/statements/statement-2017-01", result.output)
         self.assertNotIn("2018-01", result.output)
@@ -84,8 +84,8 @@ class AccountTests(N26TestBase):
     @mock_requests(method=GET, response_file="statements.json")
     def test_get_statements_by_date_cli(self):
         from n26.cli import statements
-        result = self._run_cli_cmd(statements, ['--from', '2017-01-01', '--to', '2017-04-01'])
-        self.assertEqual(len(result.output.split('\n')), 7)
+        result = self._run_cli_cmd(statements, ["--from", "2017-01-01", "--to", "2017-04-01"])
+        self.assertEqual(len(result.output.split("\n")), 7)
         self.assertNotIn("2016-11", result.output)
         self.assertIn("/api/statements/statement-2017-01", result.output)
         self.assertIn("2017-02", result.output)

--- a/tests/test_account.py
+++ b/tests/test_account.py
@@ -1,5 +1,10 @@
+import filecmp
+from glob import glob
+from os import path
+from tempfile import TemporaryDirectory
+
 from n26.api import GET, POST
-from tests.test_api_base import N26TestBase, mock_requests
+from tests.test_api_base import N26TestBase, mock_requests, read_response_file
 
 
 class AccountTests(N26TestBase):
@@ -94,3 +99,17 @@ class AccountTests(N26TestBase):
         self.assertNotIn("2018-01", result.output)
         self.assertNotIn("2019-01", result.output)
         self.assertNotIn("1554076800000", result.output)
+
+    @mock_requests(method=GET, response_file="statement.pdf", url_regex=r"/api/statements/statement-2017-01$")
+    @mock_requests(method=GET, response_file="statements.json", url_regex=r"/api/statements$")
+    def test_get_statements_download_cli(self):
+        from n26.cli import statements
+        id = "statement-2017-01"
+        with TemporaryDirectory() as dir:
+            result = self._run_cli_cmd(statements, ["--id", id, "--download", dir])
+            self.assertIn(id, result.output)
+            files = glob(f"{dir}/*.pdf")
+            self.assertTrue(len(files) == 1)
+            directory = path.dirname(__file__)
+            file_path = path.join(directory, 'api_responses', 'statement.pdf')
+            self.assertTrue(filecmp.cmp(file_path, files[0]))

--- a/tests/test_account.py
+++ b/tests/test_account.py
@@ -69,3 +69,28 @@ class AccountTests(N26TestBase):
         self.assertIn("2019-01", result.output)
         self.assertIn("/api/statements/statement-2019-04", result.output)
         self.assertIn("1554076800000", result.output)
+
+    @mock_requests(method=GET, response_file="statements.json")
+    def test_get_statements_by_id_cli(self):
+        from n26.cli import statements
+        result = self._run_cli_cmd(statements, ['--id', 'statement-2017-01'])
+        self.assertEqual(len(result.output.split('\n')), 4)
+        self.assertNotIn("2016-11", result.output)
+        self.assertIn("/api/statements/statement-2017-01", result.output)
+        self.assertNotIn("2018-01", result.output)
+        self.assertNotIn("2019-01", result.output)
+        self.assertNotIn("1554076800000", result.output)
+
+    @mock_requests(method=GET, response_file="statements.json")
+    def test_get_statements_by_date_cli(self):
+        from n26.cli import statements
+        result = self._run_cli_cmd(statements, ['--from', '2017-01-01', '--to', '2017-04-01'])
+        self.assertEqual(len(result.output.split('\n')), 7)
+        self.assertNotIn("2016-11", result.output)
+        self.assertIn("/api/statements/statement-2017-01", result.output)
+        self.assertIn("2017-02", result.output)
+        self.assertIn("2017-03", result.output)
+        self.assertIn("2017-04", result.output)
+        self.assertNotIn("2018-01", result.output)
+        self.assertNotIn("2019-01", result.output)
+        self.assertNotIn("1554076800000", result.output)

--- a/tests/test_account.py
+++ b/tests/test_account.py
@@ -1,8 +1,3 @@
-import filecmp
-from glob import glob
-from os import path
-from tempfile import TemporaryDirectory
-
 from n26.api import GET, POST
 from tests.test_api_base import N26TestBase, mock_requests, read_response_file
 
@@ -103,6 +98,10 @@ class AccountTests(N26TestBase):
     @mock_requests(method=GET, response_file="statement.pdf", url_regex=r"/api/statements/statement-2017-01$")
     @mock_requests(method=GET, response_file="statements.json", url_regex=r"/api/statements$")
     def test_get_statements_download_cli(self):
+        from filecmp import cmp
+        from glob import glob
+        from os import path
+        from tempfile import TemporaryDirectory
         from n26.cli import statements
         id = "statement-2017-01"
         with TemporaryDirectory() as dir:
@@ -112,4 +111,4 @@ class AccountTests(N26TestBase):
             self.assertTrue(len(files) == 1)
             directory = path.dirname(__file__)
             file_path = path.join(directory, 'api_responses', 'statement.pdf')
-            self.assertTrue(filecmp.cmp(file_path, files[0]))
+            self.assertTrue(cmp(file_path, files[0]))

--- a/tests/test_api_base.py
+++ b/tests/test_api_base.py
@@ -25,14 +25,10 @@ def read_response_file(file_name: str or None, to_json: bool = True) -> json or 
     if not os.path.isfile(file_path):
         raise AttributeError("Couldn't find file containing response mock data: {}".format(file_path))
 
-    if to_json:
-        with open(file_path, 'r') as myfile:
-            api_response_text = myfile.read()
-        return json.loads(api_response_text)
-
-    with open(file_path, 'rb') as myfile:
+    mode = 'r' if to_json else 'rb'
+    with open(file_path, mode) as myfile:
         api_response_text = myfile.read()
-    return api_response_text
+    return json.loads(api_response_text) if to_json else api_response_text
 
 
 def mock_auth_token(func: callable):
@@ -87,7 +83,7 @@ def mock_requests(method: str, response_file: str or None, url_regex: str = None
             response = read_response_file(response_file, to_json=not is_pdf)
             content = "" if response is None else response
             mock_request.return_value.content = content if is_pdf else str(content)
-            mock_request.return_value.json.return_value = read_response_file(response_file, to_json=not is_pdf)
+            mock_request.return_value.json.return_value = response
             return new_mock
 
         @mock_auth_token

--- a/tests/test_api_base.py
+++ b/tests/test_api_base.py
@@ -12,6 +12,7 @@ def read_response_file(file_name: str or None, to_json: bool = True) -> json or 
     """
     Reads a JSON file and returns it's content as a string
     :param file_name: the name of the file
+    :param to_json: whether to parse the file to a json object or not
     :return: file contents
     """
 

--- a/tests/test_api_base.py
+++ b/tests/test_api_base.py
@@ -79,11 +79,14 @@ def mock_requests(method: str, response_file: str or None, url_regex: str = None
 
             mock_request.side_effect = side_effect
 
-            is_pdf = response_file.endswith('.pdf') if response_file else False
-            response = read_response_file(response_file, to_json=not is_pdf)
+            is_json = response_file.endswith('.json') if response_file else False
+            response = read_response_file(response_file, to_json=is_json)
             content = "" if response is None else response
-            mock_request.return_value.content = content if is_pdf else str(content)
+            mock_request.return_value.content = content if not is_json else str(content)
             mock_request.return_value.json.return_value = response
+            mock_request.return_value.headers = {
+                "Content-Type": "application/json" if is_json else ""
+            }
             return new_mock
 
         @mock_auth_token


### PR DESCRIPTION
Hello,
since the statements-command already retrieves the urls of the statements I added an option to download these pdfs as well. Simply supply a directory via the '--download'-option to the statements-command and each statement gets saved there as separate pdf-file. Additionally there are some new options to filter statements by id or date. Useful if you just want to list / download a subset of the statements. The changes are fully backwards-compatible.
My plan with this is to grab last months statement via cronjob or so (for archival purposes). Maybe this is useful to someone else as well. Or you can somehow merge this with the existing feature/show-statement branch :)