### PR TITLE
Better statements cli

### DIFF
--- a/n26/cli.py
+++ b/n26/cli.py
@@ -2,7 +2,7 @@ import functools
 import logging
 import webbrowser
 from datetime import datetime, timezone
-from os import path
+from pathlib import Path
 from typing import Tuple
 
 import click
@@ -349,13 +349,14 @@ def statements(id: str or None, param_from: datetime or None, param_to: datetime
     if not download:
         return
 
-    output_path = path.abspath(download)
-    if not path.isdir(output_path):
+    output_path = Path(download).expanduser().resolve()
+    if not output_path.is_dir():
         click.echo("Target path doesn't exist or is not a folder, skipping download.")
         return
 
     for statement in statements_data:
-        filepath = path.join(output_path, '{0}.pdf'.format(statement["id"]))
+        filepath = Path.joinpath(output_path, f'{statement["id"]}.pdf')
+        click.echo(f"Downloading {filepath}...")
         statement_data = API_CLIENT.get_balance_statement(statement['url'])
         with open(filepath, 'wb') as f:
             f.write(statement_data)


### PR DESCRIPTION
* use pathlib api
* resolve "~"
* output filepath of the current download

When using the download functionality, I got this error when trying to download too many files at once:
```
Traceback (most recent call last):
  File "/home/markus/programming/PycharmProjects/python-n26/venv/bin/n26", line 33, in <module>
    sys.exit(load_entry_point('n26==3.2.6', 'console_scripts', 'n26')())
  File "/home/markus/programming/PycharmProjects/python-n26/venv/lib/python3.9/site-packages/click/core.py", line 829, in __call__
    return self.main(*args, **kwargs)
  File "/home/markus/programming/PycharmProjects/python-n26/venv/lib/python3.9/site-packages/click/core.py", line 782, in main
    rv = self.invoke(ctx)
  File "/home/markus/programming/PycharmProjects/python-n26/venv/lib/python3.9/site-packages/click/core.py", line 1259, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/markus/programming/PycharmProjects/python-n26/venv/lib/python3.9/site-packages/click/core.py", line 1066, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/markus/programming/PycharmProjects/python-n26/venv/lib/python3.9/site-packages/click/core.py", line 610, in invoke
    return callback(*args, **kwargs)
  File "/home/markus/programming/PycharmProjects/python-n26/venv/lib/python3.9/site-packages/n26/cli.py", line 51, in wrapper
    return func(*args, **kwargs)
  File "/home/markus/programming/PycharmProjects/python-n26/venv/lib/python3.9/site-packages/n26/cli.py", line 360, in statements
    statement_data = API_CLIENT.get_balance_statement(statement['url'])
  File "/home/markus/programming/PycharmProjects/python-n26/venv/lib/python3.9/site-packages/n26/api.py", line 231, in get_balance_statement
    return self._do_request(GET, BASE_URL_DE + statement_url)
  File "/home/markus/programming/PycharmProjects/python-n26/venv/lib/python3.9/site-packages/n26/api.py", line 310, in _do_request
    response.raise_for_status()
  File "/home/markus/programming/PycharmProjects/python-n26/venv/lib/python3.9/site-packages/requests/models.py", line 941, in raise_for_status
    raise HTTPError(http_error_msg, response=self)
requests.exceptions.HTTPError: 429 Client Error: Too Many Requests for url: https://api.tech26.de/api/balance-statements/statement-2017-02

```

Not sure if we want to handle this in python-n26 or not, we would have to include some retry or sleep functionality to avoid hitting the ratelimit of the server.